### PR TITLE
Only set basic auth HTTP header on requests to GoCD server

### DIFF
--- a/src/main/java/com/rsr5/gocd/riemann_notifier/GoApiAccessor.java
+++ b/src/main/java/com/rsr5/gocd/riemann_notifier/GoApiAccessor.java
@@ -36,7 +36,7 @@ public class GoApiAccessor {
         return con;
     }
 
-    private Boolean authRequired() {
+    private boolean authRequired() {
         return this.pluginConfig.getUsername() != null && this.pluginConfig.getPassword() != null;
     }
 

--- a/src/main/java/com/rsr5/gocd/riemann_notifier/GoApiAccessor.java
+++ b/src/main/java/com/rsr5/gocd/riemann_notifier/GoApiAccessor.java
@@ -7,13 +7,42 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Base64;
 
 public class GoApiAccessor {
+    private PluginConfig pluginConfig = null;
+
+    public GoApiAccessor(PluginConfig pluginConfig) {
+        this.pluginConfig = pluginConfig;
+    }
+
+    public GoApiAccessor() {
+        this(new PluginConfig());
+    }
+
     public JsonElement get(String path) throws IOException {
-        URL url = new URL("http", "localhost", 8153, path);
-        HttpURLConnection con = (HttpURLConnection) url.openConnection();
+        HttpURLConnection con = this.getConnection(path);
         con.setRequestProperty("Accept", "application/vnd.go.cd+json");
         con.connect();
         return JsonParser.parseReader(new InputStreamReader(con.getInputStream()));
     }
+
+    public HttpURLConnection getConnection(String path) throws IOException {
+        URL url = new URL("http", "localhost", 8153, path);
+        HttpURLConnection con = (HttpURLConnection) url.openConnection();
+        if (this.authRequired()) {
+            con.setRequestProperty("Authorization", this.getAuthHeader());
+        }
+        return con;
+    }
+
+    private Boolean authRequired() {
+        return this.pluginConfig.getUsername() != null && this.pluginConfig.getPassword() != null;
+    }
+
+    private String getAuthHeader() {
+        String authString = this.pluginConfig.getUsername() + ":" + this.pluginConfig.getPassword();
+        return Base64.getEncoder().encodeToString(authString.getBytes());
+    }
+
 }

--- a/src/main/java/com/rsr5/gocd/riemann_notifier/RetrievePipelineRSS.java
+++ b/src/main/java/com/rsr5/gocd/riemann_notifier/RetrievePipelineRSS.java
@@ -1,38 +1,22 @@
 package com.rsr5.gocd.riemann_notifier;
 
 import java.io.IOException;
-import java.net.Authenticator;
 import java.net.HttpURLConnection;
-import java.net.PasswordAuthentication;
-import java.net.URL;
 
 public class RetrievePipelineRSS {
+    private GoApiAccessor accessor = null;
 
-    PluginConfig pluginConfig = null;
-    String username = null;
-    String password = null;
+    public RetrievePipelineRSS(GoApiAccessor accessor) {
+        this.accessor = accessor;
+    }
 
     public RetrievePipelineRSS() {
-        pluginConfig = new PluginConfig();
-        username = pluginConfig.getUsername();
-        password = pluginConfig.getPassword();
+        this(new GoApiAccessor());
     }
 
     public HttpURLConnection download() throws IOException {
-        String sURL = "http://localhost:8153/go/cctray.xml";
-
-        if (username != null && password != null){
-            Authenticator.setDefault(new Authenticator() {
-                protected PasswordAuthentication getPasswordAuthentication() {
-                    return new PasswordAuthentication(username,
-                            password.toCharArray());
-                }
-            });
-        }
-
-        URL url = new URL(sURL);
-        HttpURLConnection request = (HttpURLConnection) url.openConnection();
-        request.connect();
-        return request;
+        HttpURLConnection con = accessor.getConnection("/go/cctray.xml");
+        con.connect();
+        return con;
     }
 }


### PR DESCRIPTION
Previously, this was setting the basic auth header with the plugin's
provided username and password for all HTTP requests that the GoCD
server JVM was making. This has the possibility to leak the credentials
externally.

This change makes it so that we explicitly set the basic auth header on
all requests (instead of setting the default Authentication mechanism),
and ensures that it is only set on requests to localhost.