### PR TITLE
Include JUnit test results in notifications if available

### DIFF
--- a/docker/gocd-home/gocd-riemann-notifier.conf
+++ b/docker/gocd-home/gocd-riemann-notifier.conf
@@ -1,1 +1,2 @@
 riemann_host=riemann
+junit_job_whitelist=integration

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,30 @@
             <version>1.4.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.10.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.10.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.10.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>2.10.3</version>
+        </dependency>
+
         <!-- test dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/com/rsr5/gocd/riemann_notifier/DuplicateToArrayJsonNodeDeserializer.java
+++ b/src/main/java/com/rsr5/gocd/riemann_notifier/DuplicateToArrayJsonNodeDeserializer.java
@@ -1,0 +1,34 @@
+package com.rsr5.gocd.riemann_notifier;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.JsonNodeDeserializer;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public class DuplicateToArrayJsonNodeDeserializer extends JsonNodeDeserializer {
+    @Override
+    protected void _handleDuplicateField(
+            JsonParser p,
+            DeserializationContext ctxt,
+            JsonNodeFactory nodeFactory,
+            String fieldName,
+            ObjectNode objectNode,
+            JsonNode oldValue,
+            JsonNode newValue)
+            throws JsonProcessingException {
+        ArrayNode node;
+        if (oldValue instanceof ArrayNode) {
+            node = (ArrayNode) oldValue;
+            node.add(newValue);
+        } else {
+            node = nodeFactory.arrayNode();
+            node.add(oldValue);
+            node.add(newValue);
+        }
+        objectNode.set(fieldName, node);
+    }
+}

--- a/src/main/java/com/rsr5/gocd/riemann_notifier/GoApiAccessor.java
+++ b/src/main/java/com/rsr5/gocd/riemann_notifier/GoApiAccessor.java
@@ -2,6 +2,7 @@ package com.rsr5.gocd.riemann_notifier;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+import com.thoughtworks.go.plugin.api.logging.Logger;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -10,6 +11,7 @@ import java.net.URL;
 import java.util.Base64;
 
 public class GoApiAccessor {
+    private static Logger LOGGER = Logger.getLoggerFor(GoApiAccessor.class);
     private PluginConfig pluginConfig = null;
 
     public GoApiAccessor(PluginConfig pluginConfig) {
@@ -24,6 +26,9 @@ public class GoApiAccessor {
         HttpURLConnection con = this.getConnection(path);
         con.setRequestProperty("Accept", "application/vnd.go.cd+json");
         con.connect();
+        if (200 != con.getResponseCode()) {
+            LOGGER.error("Error connecting to GoCD API: " + con.getResponseCode() + " " + con.getResponseMessage());
+        }
         return JsonParser.parseReader(new InputStreamReader(con.getInputStream()));
     }
 

--- a/src/main/java/com/rsr5/gocd/riemann_notifier/GoNotificationPlugin.java
+++ b/src/main/java/com/rsr5/gocd/riemann_notifier/GoNotificationPlugin.java
@@ -47,7 +47,7 @@ public class GoNotificationPlugin implements GoPlugin {
     @Override
     public void initializeGoApplicationAccessor(GoApplicationAccessor
                                                         goApplicationAccessor) {
-
+        LOGGER.info("Initializing plugin.");
         if (riemann == null) {
 
             PluginConfig pluginConfig = new PluginConfig();
@@ -85,10 +85,9 @@ public class GoNotificationPlugin implements GoPlugin {
             return;
         }
 
-        Iterator it = states.entrySet().iterator();
+        Iterator<Map.Entry<String, String>> it = states.entrySet().iterator();
         while (it.hasNext()) {
-            Map.Entry pair = (Map.Entry)it.next();
-            System.out.println(pair.getKey() + " = " + pair.getValue());
+            Map.Entry<String, String> pair = it.next();
 
             try{
 

--- a/src/main/java/com/rsr5/gocd/riemann_notifier/JUnitResultsParser.java
+++ b/src/main/java/com/rsr5/gocd/riemann_notifier/JUnitResultsParser.java
@@ -1,0 +1,27 @@
+package com.rsr5.gocd.riemann_notifier;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+
+import java.io.IOException;
+
+public class JUnitResultsParser {
+    private ObjectMapper objectMapper;
+    private XmlMapper xmlMapper;
+
+    public JUnitResultsParser() {
+        this.objectMapper = new ObjectMapper();
+        this.xmlMapper = new XmlMapper();
+        this.xmlMapper.registerModule(new SimpleModule().addDeserializer(
+            JsonNode.class,
+            new DuplicateToArrayJsonNodeDeserializer()
+        ));
+    }
+
+    public String fromXml(String xmlStr) throws IOException {
+        JsonNode node = xmlMapper.readTree(xmlStr);
+        return objectMapper.writeValueAsString(node);
+    }
+}

--- a/src/main/java/com/rsr5/gocd/riemann_notifier/PipelineDetailsPopulator.java
+++ b/src/main/java/com/rsr5/gocd/riemann_notifier/PipelineDetailsPopulator.java
@@ -4,14 +4,30 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+import com.thoughtworks.go.plugin.api.logging.Logger;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.regex.Pattern;
+import java.net.HttpURLConnection;
+import java.net.URL;
 
 public class PipelineDetailsPopulator {
-    private GoApiAccessor accessor = null;
+    private static Logger LOGGER = Logger.getLoggerFor(PipelineDetailsPopulator.class);
+    private GoApiAccessor accessor;
+    private JUnitResultsParser parser;
+    private PluginConfig config;
+
+    public PipelineDetailsPopulator(GoApiAccessor accessor, JUnitResultsParser parser) {
+        this.accessor = accessor;
+        this.config = new PluginConfig();
+        this.parser = parser;
+    }
 
     public PipelineDetailsPopulator(GoApiAccessor accessor) {
-        this.accessor = accessor;
+        this(accessor, new JUnitResultsParser());
     }
 
     public PipelineDetailsPopulator() {
@@ -24,6 +40,48 @@ public class PipelineDetailsPopulator {
         JsonObject json = notification.getAsJsonObject();
         json.add(attributeName, pipelineInstance);
         return json;
+    }
+
+    /**
+     * Performs a depth-first search of the artifacts, returning a JsonObject
+     * translation of the first artifact named "results.xml".
+     */
+    protected JsonElement findJunitResults(JsonArray artifacts) throws IOException {
+        for (JsonElement element : artifacts) {
+            JsonObject artifact = element.getAsJsonObject();
+            if ("folder".equals(artifact.get("type").getAsString())) {
+                JsonElement result = findJunitResults(artifact.get("files").getAsJsonArray());
+                if (null != result) {
+                    return result;
+                }
+            } else if ("file".equals(artifact.get("type").getAsString()) &&
+                       "results.xml".equals(artifact.get("name").getAsString())) {
+                URL url = new URL(artifact.get("url").getAsString());
+                HttpURLConnection con = accessor.getConnection(url.getPath());
+                con.connect();
+                if (con.getResponseCode() != 200) {
+                    LOGGER.error("Server returned error when trying to get JUnit results: " + con.getResponseMessage());
+                    return null;
+                }
+                StringBuffer response = new StringBuffer();
+                try (BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()))) {
+                    String inputLine;
+
+                    while ((inputLine = in.readLine()) != null) {
+                        response.append(inputLine);
+                    }
+                }
+                String junitJson = parser.fromXml(response.toString());
+
+                try {
+                    return JsonParser.parseString(junitJson);
+                } catch (JsonSyntaxException e) {
+                    LOGGER.error("Failed to parse JUnit JSON results", e);
+                    return null;
+                }
+            }
+        }
+        return null;
     }
 
     protected JsonObject downloadPipelineArtifacts(String pipelineName,
@@ -47,6 +105,10 @@ public class PipelineDetailsPopulator {
             JsonObject pipelineObject = json.get("pipeline").getAsJsonObject();
             JsonObject stageObject = pipelineObject.get("stage").getAsJsonObject();
 
+            if ("Building".equals(stageObject.get("state").getAsString())) {
+                return json;
+            }
+
             String pipeline = pipelineObject.get("name").getAsString();
             String pipelineCounter = pipelineObject.get("counter")
                     .getAsString();
@@ -58,17 +120,30 @@ public class PipelineDetailsPopulator {
 
             JsonArray jobs = stageObject.get("jobs").getAsJsonArray();
             for(final JsonElement job : jobs) {
+                String jobName = job.getAsJsonObject().get("name").getAsString();
 
-                JsonObject extraDetails = downloadPipelineArtifacts(pipeline, stage,
-                        pipelineCounter, stageCounter, job.getAsJsonObject().get("name").getAsString());
-                jobArtifacts.add(extraDetails);
+                JsonElement artifacts = downloadPipelineArtifacts(pipeline, stage, pipelineCounter, stageCounter, jobName);
+                jobArtifacts.add(artifacts);
+
+                if (null != this.config.getJUnitJobWhitelist() &&
+                    Pattern.matches(this.config.getJUnitJobWhitelist(), jobName)) {
+                    try {
+                        JsonElement junitResults = findJunitResults(artifacts.getAsJsonObject().get(jobName).getAsJsonArray());
+                        if (null != junitResults) {
+                            json.add("x-junit-results", junitResults);
+                        }
+                    } catch (IOException e) {
+                        json.addProperty("x-pipeline-error", "Error downloading pipeline test history.");
+                        LOGGER.error("Error downloading pipeline test history", e);
+                    }
+                }
             }
 
             json = mergeInPipelineInstanceDetails("x-pipeline-artifacts",
                     json, jobArtifacts);
         } catch (IOException e) {
-            json.addProperty("x-pipeline-error", "Error connecting to GoCD " +
-                    "API.");
+            json.addProperty("x-pipeline-error", "Error connecting to GoCD API.");
+            LOGGER.error("Error connecting to GoCD API", e);
         }
 
         return json;

--- a/src/main/java/com/rsr5/gocd/riemann_notifier/PluginConfig.java
+++ b/src/main/java/com/rsr5/gocd/riemann_notifier/PluginConfig.java
@@ -16,6 +16,7 @@ public class PluginConfig {
     private long fetchInterval = 59000;
     private String username = null;
     private String password = null;
+    private String junitJobWhitelist = null;
 
     public PluginConfig() {
         String userHome = System.getProperty("user.home");
@@ -44,6 +45,10 @@ public class PluginConfig {
             if (config.hasPath("password")) {
                 password = config.getString("password");
             }
+
+            if (config.hasPath("junit_job_whitelist")) {
+                junitJobWhitelist = config.getString("junit_job_whitelist");
+            }
         }
     }
 
@@ -56,4 +61,5 @@ public class PluginConfig {
     public long getFetchInterval() { return fetchInterval; }
     public String getPassword() { return password; }
     public String getUsername() { return username; }
+    public String getJUnitJobWhitelist() { return junitJobWhitelist; }
 }

--- a/src/test/java/com/rsr5/gocd/riemann_notifier/TestJUnitResultsParser.java
+++ b/src/test/java/com/rsr5/gocd/riemann_notifier/TestJUnitResultsParser.java
@@ -1,0 +1,37 @@
+package com.rsr5.gocd.riemann_notifier;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class TestJUnitResultsParser {
+    private String readFile(String path) throws IOException {
+        byte[] encoded = Files.readAllBytes(Paths.get(path));
+        return new String(encoded);
+    }
+
+    @Test
+    public void testFromXml() throws IOException {
+        JUnitResultsParser parser = new JUnitResultsParser();
+
+        String input = this.readFile("src/test/junit_results.xml");
+        String expected = this.readFile("src/test/junit_results.json");
+
+        String actual = parser.fromXml(input);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode expectedNode = objectMapper.readTree(expected);
+        JsonNode actualNode = objectMapper.readTree(actual);
+
+        if (!expectedNode.equals(actualNode)) {
+            fail("JUnit parsing failed. Expected: " + expectedNode.toString() +
+                    ", got: " + actualNode.toString());
+        }
+    }
+}

--- a/src/test/java/com/rsr5/gocd/riemann_notifier/TestPipelineDetailsPopulator.java
+++ b/src/test/java/com/rsr5/gocd/riemann_notifier/TestPipelineDetailsPopulator.java
@@ -26,7 +26,6 @@ public class TestPipelineDetailsPopulator {
         PipelineDetailsPopulator pipelineDetailsPopulator = new
                 PipelineDetailsPopulator(accessor);
 
-        String contentArtifacts = "{}";
         String requestBody = "{}";
         try {
             requestBody = this.readFile("src/test/example_notification.json");
@@ -34,6 +33,7 @@ public class TestPipelineDetailsPopulator {
             System.out.println("can't load file example_notification.json");
         }
 
+        String contentArtifacts = "{}";
         try {
             contentArtifacts = this.readFile("src/test/test_contents_artifacts.json");
         } catch (IOException e) {

--- a/src/test/junit_results.json
+++ b/src/test/junit_results.json
@@ -1,0 +1,95 @@
+{
+  "testsuite": [
+    {
+      "name": "testsuite-a",
+      "timestamp": "2020-04-18T20:00:00.000Z",
+      "tests": "3",
+      "time": "10.500",
+      "errors": "0",
+      "failures": "0",
+      "skipped": "0",
+      "testcase": [
+        {
+          "name": "test case the first",
+          "classname": "foo.bar.baz-test",
+          "time": "3.000"
+        },
+        {
+          "name": "test case the second",
+          "classname": "foo.bar.baz-test",
+          "time": "4.000"
+        },
+        {
+          "name": "test case the third",
+          "classname": "foo.bar.baz-test",
+          "time": "3.500"
+        }
+      ]
+    },
+    {
+      "name": "testsuite-b",
+      "timestamp": "2020-04-18T20:00:15.000Z",
+      "tests": "5",
+      "time": "20.000",
+      "errors": "0",
+      "failures": "1",
+      "skipped": "2",
+      "testcase": [
+        {
+          "name": "first test case",
+          "classname": "bar.baz.foo-test",
+          "time": "5.000"
+        },
+        {
+          "name": "second test case",
+          "classname": "bar.baz.foo-test",
+          "time": "5.000"
+        },
+        {
+          "name": "third test case",
+          "classname": "bar.baz.foo-test",
+          "time": "8.000",
+          "failure": {
+            "message": "1 assertions (1 fail)"
+          }
+        },
+        {
+          "name": "fourth test case",
+          "classname": "bar.baz.foo-test",
+          "time": "0.011",
+          "skipped": null
+        },
+        {
+          "name": "fifth test case",
+          "classname": "bar.baz.foo-test",
+          "time": "0.012",
+          "skipped": null
+        }
+      ]
+    },
+    {
+      "name": "testsuite-c",
+      "timestamp": "2020-04-18T20:00:35.000Z",
+      "tests": "2",
+      "time": "10.000",
+      "errors": "1",
+      "failures": "0",
+      "skipped": "0",
+      "testcase": [
+        {
+          "name": "first test case",
+          "classname": "baz.bar.foo-test",
+          "time": "5.000"
+        },
+        {
+          "name": "second test case",
+          "classname": "baz.bar.foo-test",
+          "time": "5.000",
+          "error": {
+            "message": "exception!"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/junit_results.xml
+++ b/src/test/junit_results.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="testsuite-a" timestamp="2020-04-18T20:00:00.000Z" tests="3" time="10.500" errors="0" failures="0" skipped="0">
+    <testcase name="test case the first" classname="foo.bar.baz-test" time="3.000"/>
+    <testcase name="test case the second" classname="foo.bar.baz-test" time="4.000"/>
+    <testcase name="test case the third" classname="foo.bar.baz-test" time="3.500"/>
+  </testsuite>
+  <testsuite name="testsuite-b" timestamp="2020-04-18T20:00:15.000Z" tests="5" time="20.000" errors="0" failures="1" skipped="2">
+    <testcase name="first test case" classname="bar.baz.foo-test" time="5.000"/>
+    <testcase name="second test case" classname="bar.baz.foo-test" time="5.000"/>
+    <testcase name="third test case" classname="bar.baz.foo-test" time="8.000">
+      <failure message="1 assertions (1 fail)"/>
+    </testcase>
+    <testcase name="fourth test case" classname="bar.baz.foo-test" time="0.011">
+      <skipped/>
+    </testcase>
+    <testcase name="fifth test case" classname="bar.baz.foo-test" time="0.012">
+      <skipped/>
+    </testcase>
+  </testsuite>
+  <testsuite name="testsuite-c" timestamp="2020-04-18T20:00:35.000Z" tests="2" time="10.000" errors="1" failures="0" skipped="0">
+    <testcase name="first test case" classname="baz.bar.foo-test" time="5.000"/>
+    <testcase name="second test case" classname="baz.bar.foo-test" time="5.000">
+      <error message="exception!"/>
+    </testcase>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
In the GoCD UI, GoCD automatically generates a "tests" results page for
you if you generate a test artifact with the name `results.xml` that
conforms to the JUnit results spec.

This PR adds support for including the contents of that artifact with
the Riemann notification by looking for said test artifact, performing
an XML -> JSON transform on it, and including the result in the
notification if possible.

This PR depends on #9, please review that one first.