### PR TITLE
Add stage and job duration riemann metrics.

### DIFF
--- a/src/main/java/com/rsr5/gocd/riemann_notifier/GoNotificationPlugin.java
+++ b/src/main/java/com/rsr5/gocd/riemann_notifier/GoNotificationPlugin.java
@@ -168,28 +168,36 @@ public class GoNotificationPlugin implements GoPlugin {
             public final Instant end;
 
             public JobData(JsonObject json) {
+                String start = safeGetAsString(json, "schedule-time");
+                String end = safeGetAsString(json, "complete-time");
+
                 this.name = safeGetAsString(json, "name");
                 this.result = safeGetAsString(json, "result");
-                this.start = Instant.parse(safeGetAsString(json, "schedule-time"));
-                this.end = Instant.parse(safeGetAsString(json, "complete-time"));
+                this.start = start == null ? null : Instant.parse(start);
+                this.end = end == null ? null : Instant.parse(end);
             }
 
-            public long getDurationInSeconds() {
-                return ChronoUnit.SECONDS.between(this.start, this.end);
+            public Long getDurationInSeconds() {
+                if (this.start != null && this.end != null) {
+                    return ChronoUnit.SECONDS.between(this.start, this.end);
+                }
+                return null;
             }
         }
 
         public StageData(JsonObject json) {
             JsonObject pipelineObject = (JsonObject) json.get("pipeline");
             JsonObject stageObject = (JsonObject) pipelineObject.get("stage");
+            String start = safeGetAsString(stageObject, "create-time");
+            String end = safeGetAsString(stageObject, "last-transition-time");
             List<JobData> jobs = new ArrayList<JobData>();
 
             this.pipeline = safeGetAsString(pipelineObject, "name");
             this.counter = safeGetAsString(pipelineObject, "counter");
             this.stage = safeGetAsString(stageObject, "name");
             this.state = safeGetAsString(stageObject, "state");
-            this.start = Instant.parse(safeGetAsString(stageObject, "create-time"));
-            this.end = Instant.parse(safeGetAsString(stageObject, "last-transition-time"));
+            this.start = start == null ? null : Instant.parse(start);
+            this.end = end == null ? null : Instant.parse(end);
 
             JsonArray jobsArray = stageObject.getAsJsonArray("jobs");
             if (jobsArray != null) {
@@ -204,8 +212,11 @@ public class GoNotificationPlugin implements GoPlugin {
             return "gocd:" + this.pipeline + ":" + this.stage;
         }
 
-        public long getDurationInSeconds() {
-            return ChronoUnit.SECONDS.between(this.start, this.end);
+        public Long getDurationInSeconds() {
+            if (this.start != null && this.end != null) {
+                return ChronoUnit.SECONDS.between(this.start, this.end);
+            }
+            return null;
         }
     }
 

--- a/src/test/java/com/rsr5/gocd/riemann_notifier/TestGoNotificationPlugin.java
+++ b/src/test/java/com/rsr5/gocd/riemann_notifier/TestGoNotificationPlugin.java
@@ -2,6 +2,7 @@ package com.rsr5.gocd.riemann_notifier;
 
 import com.google.gson.JsonParser;
 import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
+import io.riemann.riemann.Proto.Event;
 import io.riemann.riemann.Proto.Msg;
 import io.riemann.riemann.client.EventDSL;
 import io.riemann.riemann.client.IPromise;
@@ -55,9 +56,14 @@ public class TestGoNotificationPlugin {
         GoPluginApiRequest apiRequest = mock(GoPluginApiRequest.class);
 
         when(client.event()).thenReturn(eventDSL);
+        when(client.sendEvent(any(Event.class))).thenReturn(msg);
+        when(client.sendEvents(anyListOf(Event.class))).thenReturn(msg);
         when(eventDSL.service(anyString())).thenReturn(eventDSL);
         when(eventDSL.description(anyString())).thenReturn(eventDSL);
         when(eventDSL.state(anyString())).thenReturn(eventDSL);
+        when(eventDSL.time(anyLong())).thenReturn(eventDSL);
+        when(eventDSL.metric(anyLong())).thenReturn(eventDSL);
+        when(eventDSL.attribute(anyString(), anyString())).thenReturn(eventDSL);
         when(eventDSL.send()).thenReturn(msg);
 
         try {
@@ -79,6 +85,8 @@ public class TestGoNotificationPlugin {
         goNotificationPlugin.handleStageNotification(apiRequest);
 
         verify(eventDSL, times(1)).service("gocd:pipeline1:stage1");
-        verify(eventDSL, times(1)).state("Passed");
+        verify(eventDSL, times(1)).service("gocd:stage-duration");
+        verify(eventDSL, times(1)).service("gocd:job-duration");
+        verify(eventDSL, times(3)).state("Passed");
     }
 }


### PR DESCRIPTION
Unit tests pass. Additionally manually validated outputs for multi-stage and multi-job pipelines, with passing and failing cases.

Passing sample outputs:
```
INFO [2021-03-23 20:23:57,270] defaultEventExecutorGroup-2-2 - riemann.config - event:  #riemann.codec.Event{:host 71ff793e8e5c, :service gocd:stage-duration, :state Passed, :description nil, :metric 48, :tags nil, :time 1616530988, :ttl 60, :pipeline riemann-notifier, :stage build, :run-id 1}
INFO [2021-03-23 20:23:57,270] defaultEventExecutorGroup-2-2 - riemann.config - event:  #riemann.codec.Event{:host 71ff793e8e5c, :service gocd:job-duration, :state Passed, :description nil, :metric 48, :tags nil, :time 1616530988, :ttl 60, :pipeline riemann-notifier, :stage build, :run-id 1, :job build}
INFO [2021-03-23 20:23:57,270] defaultEventExecutorGroup-2-2 - riemann.config - event:  #riemann.codec.Event{:host 71ff793e8e5c, :service gocd:job-duration, :state Passed, :description nil, :metric 15, :tags nil, :time 1616530988, :ttl 60, :pipeline riemann-notifier, :stage build, :run-id 1, :job clean}

INFO [2021-03-23 20:24:19,824] defaultEventExecutorGroup-2-2 - riemann.config - event:  #riemann.codec.Event{:host 71ff793e8e5c, :service gocd:stage-duration, :state Passed, :description nil, :metric 22, :tags nil, :time 1616531037, :ttl 60, :pipeline riemann-notifier, :stage deploy, :run-id 1}
INFO [2021-03-23 20:24:19,824] defaultEventExecutorGroup-2-2 - riemann.config - event:  #riemann.codec.Event{:host 71ff793e8e5c, :service gocd:job-duration, :state Passed, :description nil, :metric 22, :tags nil, :time 1616531037, :ttl 60, :pipeline riemann-notifier, :stage deploy, :run-id 1, :job deploy}
```

Sample output with a failing job:
```
INFO [2021-03-23 20:40:56,366] defaultEventExecutorGroup-2-3 - riemann.config - event:  #riemann.codec.Event{:host 71ff793e8e5c, :service gocd:stage-duration, :state Passed, :description nil, :metric 52, :tags nil, :time 1616532003, :ttl 60, :pipeline riemann-notifier, :stage build, :run-id 13}
INFO [2021-03-23 20:40:56,366] defaultEventExecutorGroup-2-3 - riemann.config - event:  #riemann.codec.Event{:host 71ff793e8e5c, :service gocd:job-duration, :state Passed, :description nil, :metric 52, :tags nil, :time 1616532003, :ttl 60, :pipeline riemann-notifier, :stage build, :run-id 13, :job build}
INFO [2021-03-23 20:40:56,366] defaultEventExecutorGroup-2-3 - riemann.config - event:  #riemann.codec.Event{:host 71ff793e8e5c, :service gocd:job-duration, :state Passed, :description nil, :metric 19, :tags nil, :time 1616532003, :ttl 60, :pipeline riemann-notifier, :stage build, :run-id 13, :job clean}

INFO [2021-03-23 20:41:18,860] defaultEventExecutorGroup-2-3 - riemann.config - event:  #riemann.codec.Event{:host 71ff793e8e5c, :service gocd:stage-duration, :state Failed, :description nil, :metric 22, :tags nil, :time 1616532056, :ttl 60, :pipeline riemann-notifier, :stage deploy, :run-id 13}
INFO [2021-03-23 20:41:18,860] defaultEventExecutorGroup-2-3 - riemann.config - event:  #riemann.codec.Event{:host 71ff793e8e5c, :service gocd:job-duration, :state Failed, :description nil, :metric 22, :tags nil, :time 1616532056, :ttl 60, :pipeline riemann-notifier, :stage deploy, :run-id 13, :job deploy}
```